### PR TITLE
New interfaces for incoming QoS features

### DIFF
--- a/rclcpp/include/rclcpp/callback_group.hpp
+++ b/rclcpp/include/rclcpp/callback_group.hpp
@@ -22,6 +22,7 @@
 
 #include "rclcpp/client.hpp"
 #include "rclcpp/service.hpp"
+#include "rclcpp/publisher.hpp"
 #include "rclcpp/subscription.hpp"
 #include "rclcpp/timer.hpp"
 #include "rclcpp/visibility_control.hpp"
@@ -62,6 +63,10 @@ public:
   explicit CallbackGroup(CallbackGroupType group_type);
 
   RCLCPP_PUBLIC
+  const std::vector<rclcpp::PublisherBase::WeakPtr> &
+  get_publisher_ptrs() const;
+
+  RCLCPP_PUBLIC
   const std::vector<rclcpp::SubscriptionBase::WeakPtr> &
   get_subscription_ptrs() const;
 
@@ -94,6 +99,10 @@ protected:
 
   RCLCPP_PUBLIC
   void
+  add_publisher(const rclcpp::PublisherBase::SharedPtr publisher_ptr);
+
+  RCLCPP_PUBLIC
+  void
   add_subscription(const rclcpp::SubscriptionBase::SharedPtr subscription_ptr);
 
   RCLCPP_PUBLIC
@@ -119,6 +128,7 @@ protected:
   CallbackGroupType type_;
   // Mutex to protect the subsequent vectors of pointers.
   mutable std::mutex mutex_;
+  std::vector<rclcpp::PublisherBase::WeakPtr> publisher_ptrs_;
   std::vector<rclcpp::SubscriptionBase::WeakPtr> subscription_ptrs_;
   std::vector<rclcpp::TimerBase::WeakPtr> timer_ptrs_;
   std::vector<rclcpp::ServiceBase::WeakPtr> service_ptrs_;

--- a/rclcpp/include/rclcpp/create_publisher.hpp
+++ b/rclcpp/include/rclcpp/create_publisher.hpp
@@ -31,6 +31,8 @@ create_publisher(
   rclcpp::node_interfaces::NodeTopicsInterface * node_topics,
   const std::string & topic_name,
   const rmw_qos_profile_t & qos_profile,
+  const PublisherEventCallbacks & event_callbacks,
+  rclcpp::callback_group::CallbackGroup::SharedPtr group,
   bool use_intra_process_comms,
   std::shared_ptr<AllocatorT> allocator)
 {
@@ -39,10 +41,12 @@ create_publisher(
 
   auto pub = node_topics->create_publisher(
     topic_name,
-    rclcpp::create_publisher_factory<MessageT, AllocatorT, PublisherT>(allocator),
+    rclcpp::create_publisher_factory<MessageT, AllocatorT, PublisherT>(event_callbacks, allocator),
     publisher_options,
     use_intra_process_comms);
-  node_topics->add_publisher(pub);
+
+  node_topics->add_publisher(pub, group);
+
   return std::dynamic_pointer_cast<PublisherT>(pub);
 }
 

--- a/rclcpp/include/rclcpp/create_subscription.hpp
+++ b/rclcpp/include/rclcpp/create_subscription.hpp
@@ -38,6 +38,7 @@ create_subscription(
   const std::string & topic_name,
   CallbackT && callback,
   const rmw_qos_profile_t & qos_profile,
+  const SubscriptionEventCallbacks & event_callbacks,
   rclcpp::callback_group::CallbackGroup::SharedPtr group,
   bool ignore_local_publications,
   bool use_intra_process_comms,
@@ -52,7 +53,10 @@ create_subscription(
 
   auto factory = rclcpp::create_subscription_factory
     <MessageT, CallbackT, AllocatorT, CallbackMessageT, SubscriptionT>(
-    std::forward<CallbackT>(callback), msg_mem_strat, allocator);
+    std::forward<CallbackT>(callback),
+    event_callbacks,
+    msg_mem_strat,
+    allocator);
 
   auto sub = node_topics->create_subscription(
     topic_name,

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -139,7 +139,7 @@ public:
   const std::vector<rclcpp::callback_group::CallbackGroup::WeakPtr> &
   get_callback_groups() const;
 
-  /// Create and return a Publisher.
+  /// Create and return a Publisher. Note: This constructor is deprecated
   /**
    * \param[in] topic_name The topic for this publisher to publish on.
    * \param[in] qos_history_depth The depth of the publisher message queue.
@@ -151,10 +151,11 @@ public:
     typename PublisherT = ::rclcpp::Publisher<MessageT, Alloc>>
   std::shared_ptr<PublisherT>
   create_publisher(
-    const std::string & topic_name, size_t qos_history_depth,
+    const std::string & topic_name,
+    size_t qos_history_depth,
     std::shared_ptr<Alloc> allocator = nullptr);
 
-  /// Create and return a Publisher.
+  /// Create and return a Publisher. Note: this constructor is deprecated
   /**
    * \param[in] topic_name The topic for this publisher to publish on.
    * \param[in] qos_profile The quality of service profile to pass on to the rmw implementation.
@@ -170,7 +171,23 @@ public:
     const rmw_qos_profile_t & qos_profile = rmw_qos_profile_default,
     std::shared_ptr<Alloc> allocator = nullptr);
 
-  /// Create and return a Subscription.
+  /// Create and return a Publisher.
+  /**
+   * \param[in] topic_name The topic for this publisher to publish on.
+   * \param[in] options Additional options for the created Publisher
+   * \return Shared pointer to the created publisher.
+   */
+  template<
+    typename MessageT,
+    typename Alloc = std::allocator<void>,
+    typename PublisherT = ::rclcpp::Publisher<MessageT, Alloc>>
+  std::shared_ptr<PublisherT>
+  create_publisher(
+    const std::string & topic_name,
+    const PublisherOptions<Alloc> & options,
+    rclcpp::callback_group::CallbackGroup::SharedPtr callback_group = nullptr);
+
+  /// Create and return a Subscription. Note: this constructor is deprecated
   /**
    * \param[in] topic_name The topic to subscribe on.
    * \param[in] callback The user-defined callback function.
@@ -203,7 +220,7 @@ public:
     msg_mem_strat = nullptr,
     std::shared_ptr<Alloc> allocator = nullptr);
 
-  /// Create and return a Subscription.
+  /// Create and return a Subscription. Note: this constructor is deprecated
   /**
    * \param[in] topic_name The topic to subscribe on.
    * \param[in] qos_history_depth The depth of the subscription's incoming message queue.
@@ -235,6 +252,34 @@ public:
       typename rclcpp::subscription_traits::has_message_type<CallbackT>::type, Alloc>::SharedPtr
     msg_mem_strat = nullptr,
     std::shared_ptr<Alloc> allocator = nullptr);
+
+  /// Create and return a Subscription.
+  /**
+   * \param[in] topic_name The topic to subscribe on.
+   * \param[in] callback The user-defined callback function to receive a message
+   * \param[in] options Additional options for the creation of the Subscription
+   * \param[in] msg_mem_strat The message memory strategy to use for allocating messages.
+   * \return Shared pointer to the created subscription.
+   */
+  /* TODO(jacquelinekay):
+     Windows build breaks when static member function passed as default
+     argument to msg_mem_strat, nullptr is a workaround.
+   */
+  template<
+    typename MessageT,
+    typename CallbackT,
+    typename Alloc = std::allocator<void>,
+    typename SubscriptionT = rclcpp::Subscription<
+      typename rclcpp::subscription_traits::has_message_type<CallbackT>::type, Alloc>>
+  std::shared_ptr<SubscriptionT>
+  create_subscription(
+    const std::string & topic_name,
+    CallbackT && callback,
+    const SubscriptionOptions<Alloc> & options,
+    rclcpp::callback_group::CallbackGroup::SharedPtr callback_group = nullptr,
+    typename rclcpp::message_memory_strategy::MessageMemoryStrategy<
+      typename rclcpp::subscription_traits::has_message_type<CallbackT>::type, Alloc>::SharedPtr
+    msg_mem_strat = nullptr);
 
   /// Create a timer.
   /**
@@ -599,6 +644,16 @@ public:
   RCLCPP_PUBLIC
   const NodeOptions &
   get_node_options() const;
+
+  /// Manually assert that this Node is alive (for RMW_QOS_POLICY_MANUAL_BY_NODE)
+  /**
+   * If the rmw Liveliness policy is set to RMW_QOS_POLICY_MANUAL_BY_NODE, the creator of this
+   * Node must manually call `assert_liveliness` periodically to signal that this Node
+   * is still alive. Must be called at least as often as qos_profile's Liveliness lease_duration
+   */
+  RCLCPP_PUBLIC
+  void
+  assert_liveliness() {}
 
 protected:
   /// Construct a sub-node, which will extend the namespace of all entities created with it.

--- a/rclcpp/include/rclcpp/node_interfaces/node_topics.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_topics.hpp
@@ -58,7 +58,8 @@ public:
   virtual
   void
   add_publisher(
-    rclcpp::PublisherBase::SharedPtr publisher);
+    rclcpp::PublisherBase::SharedPtr publisher,
+    rclcpp::callback_group::CallbackGroup::SharedPtr callback_group);
 
   RCLCPP_PUBLIC
   virtual

--- a/rclcpp/include/rclcpp/node_interfaces/node_topics_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_topics_interface.hpp
@@ -57,7 +57,8 @@ public:
   virtual
   void
   add_publisher(
-    rclcpp::PublisherBase::SharedPtr publisher) = 0;
+    rclcpp::PublisherBase::SharedPtr publisher,
+    rclcpp::callback_group::CallbackGroup::SharedPtr callback_group) = 0;
 
   RCLCPP_PUBLIC
   virtual

--- a/rclcpp/include/rclcpp/parameter_client.hpp
+++ b/rclcpp/include/rclcpp/parameter_client.hpp
@@ -127,6 +127,7 @@ public:
       "parameter_events",
       std::forward<CallbackT>(callback),
       rmw_qos_profile_default,
+      SubscriptionEventCallbacks(),
       nullptr,  // group,
       false,  // ignore_local_publications,
       false,  // use_intra_process_comms_,

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -31,17 +31,21 @@
 
 #include "rclcpp/allocator/allocator_common.hpp"
 #include "rclcpp/allocator/allocator_deleter.hpp"
+#include "rclcpp/exceptions.hpp"
 #include "rclcpp/macros.hpp"
-#include "rclcpp/node_interfaces/node_base_interface.hpp"
+#include "rclcpp/publisher_options.hpp"
 #include "rclcpp/type_support_decl.hpp"
 #include "rclcpp/visibility_control.hpp"
 
 namespace rclcpp
 {
 
-// Forward declaration is used for friend statement.
 namespace node_interfaces
 {
+// NOTE(emersonknapp) Forward declaration avoids including node_base_interface.hpp which causes
+// circular inclusion from callback_group.hpp
+class NodeBaseInterface;
+// Forward declaration is used for friend statement.
 class NodeTopicsInterface;
 }
 
@@ -128,6 +132,16 @@ public:
   size_t
   get_intra_process_subscription_count() const;
 
+  /// Manually assert that this Publisher is alive (for RMW_QOS_POLICY_MANUAL_BY_TOPIC)
+  /**
+   * If the rmw Liveliness policy is set to RMW_QOS_POLICY_MANUAL_BY_TOPIC, the creator of this
+   * Publisher must manually call `assert_liveliness` periodically to signal that this Publisher
+   * is still alive. Must be called at least as often as qos_profile's Liveliness lease_duration
+   */
+  RCLCPP_PUBLIC
+  void
+  assert_liveliness() {}
+
   /// Compare this publisher to a gid.
   /**
    * Note that this function calls the next function.
@@ -194,6 +208,7 @@ public:
     rclcpp::node_interfaces::NodeBaseInterface * node_base,
     const std::string & topic,
     const rcl_publisher_options_t & publisher_options,
+    const PublisherEventCallbacks & /* event_callbacks */,
     const std::shared_ptr<MessageAlloc> & allocator)
   : PublisherBase(
       node_base,

--- a/rclcpp/include/rclcpp/publisher_factory.hpp
+++ b/rclcpp/include/rclcpp/publisher_factory.hpp
@@ -75,13 +75,15 @@ struct PublisherFactory
 /// Return a PublisherFactory with functions setup for creating a PublisherT<MessageT, Alloc>.
 template<typename MessageT, typename Alloc, typename PublisherT>
 PublisherFactory
-create_publisher_factory(std::shared_ptr<Alloc> allocator)
+create_publisher_factory(
+  const PublisherEventCallbacks & event_callbacks,
+  std::shared_ptr<Alloc> allocator)
 {
   PublisherFactory factory;
 
   // factory function that creates a MessageT specific PublisherT
   factory.create_typed_publisher =
-    [allocator](
+    [event_callbacks, allocator](
     rclcpp::node_interfaces::NodeBaseInterface * node_base,
     const std::string & topic_name,
     rcl_publisher_options_t & publisher_options) -> std::shared_ptr<PublisherT>
@@ -89,7 +91,8 @@ create_publisher_factory(std::shared_ptr<Alloc> allocator)
       auto message_alloc = std::make_shared<typename PublisherT::MessageAlloc>(*allocator.get());
       publisher_options.allocator = allocator::get_rcl_allocator<MessageT>(*message_alloc.get());
 
-      return std::make_shared<PublisherT>(node_base, topic_name, publisher_options, message_alloc);
+      return std::make_shared<PublisherT>(node_base, topic_name, publisher_options,
+               event_callbacks, message_alloc);
     };
 
   // function to add a publisher to the intra process manager

--- a/rclcpp/include/rclcpp/publisher_options.hpp
+++ b/rclcpp/include/rclcpp/publisher_options.hpp
@@ -1,0 +1,44 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__PUBLISHER_OPTIONS_HPP_
+#define RCLCPP__PUBLISHER_OPTIONS_HPP_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rclcpp/visibility_control.hpp"
+
+namespace rclcpp
+{
+
+/// Contains callbacks for various types of events a Publisher can receive from the middleware
+struct PublisherEventCallbacks
+{
+  // NOTE: empty placeholder for addition of QoS event callbacks
+};
+
+/// Structure containing configuration options for Publishers/Subscribers
+template<typename Alloc = std::allocator<void>>
+struct PublisherOptions
+{
+  PublisherEventCallbacks event_callbacks;
+  rmw_qos_profile_t qos_profile = rmw_qos_profile_default;
+  std::shared_ptr<Alloc> allocator = nullptr;
+};
+
+}  // namespace rclcpp
+
+#endif  // RCLCPP__PUBLISHER_OPTIONS_HPP_

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -34,6 +34,7 @@
 #include "rclcpp/expand_topic_or_service_name.hpp"
 #include "rclcpp/macros.hpp"
 #include "rclcpp/message_memory_strategy.hpp"
+#include "rclcpp/subscription_options.hpp"
 #include "rclcpp/subscription_traits.hpp"
 #include "rclcpp/type_support_decl.hpp"
 #include "rclcpp/visibility_control.hpp"
@@ -195,6 +196,7 @@ public:
     const std::string & topic_name,
     const rcl_subscription_options_t & subscription_options,
     AnySubscriptionCallback<CallbackMessageT, Alloc> callback,
+    const SubscriptionEventCallbacks & /* event_callbacks */,
     typename message_memory_strategy::MessageMemoryStrategy<CallbackMessageT, Alloc>::SharedPtr
     memory_strategy = message_memory_strategy::MessageMemoryStrategy<CallbackMessageT,
     Alloc>::create_default())

--- a/rclcpp/include/rclcpp/subscription_factory.hpp
+++ b/rclcpp/include/rclcpp/subscription_factory.hpp
@@ -75,6 +75,7 @@ template<
 SubscriptionFactory
 create_subscription_factory(
   CallbackT && callback,
+  const SubscriptionEventCallbacks & event_callbacks,
   typename rclcpp::message_memory_strategy::MessageMemoryStrategy<
     CallbackMessageT, Alloc>::SharedPtr
   msg_mem_strat,
@@ -91,7 +92,7 @@ create_subscription_factory(
 
   // factory function that creates a MessageT specific SubscriptionT
   factory.create_typed_subscription =
-    [allocator, msg_mem_strat, any_subscription_callback, message_alloc](
+    [allocator, msg_mem_strat, any_subscription_callback, event_callbacks, message_alloc](
     rclcpp::node_interfaces::NodeBaseInterface * node_base,
     const std::string & topic_name,
     rcl_subscription_options_t & subscription_options
@@ -109,6 +110,7 @@ create_subscription_factory(
         topic_name,
         subscription_options,
         any_subscription_callback,
+        event_callbacks,
         msg_mem_strat);
       auto sub_base_ptr = std::dynamic_pointer_cast<SubscriptionBase>(sub);
       return sub_base_ptr;

--- a/rclcpp/include/rclcpp/subscription_options.hpp
+++ b/rclcpp/include/rclcpp/subscription_options.hpp
@@ -1,0 +1,44 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__SUBSCRIPTION_OPTIONS_HPP_
+#define RCLCPP__SUBSCRIPTION_OPTIONS_HPP_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rclcpp/visibility_control.hpp"
+
+namespace rclcpp
+{
+
+/// Contains callbacks for non-message events that a Subscriber can receive from the middleware
+struct SubscriptionEventCallbacks
+{
+  // NOTE: placeholder for addition of QoS Event callbacks
+};
+
+template<typename Alloc = std::allocator<void>>
+struct SubscriptionOptions
+{
+  SubscriptionEventCallbacks event_callbacks;
+  rmw_qos_profile_t qos_profile = rmw_qos_profile_default;
+  bool ignore_local_publications = false;
+  std::shared_ptr<Alloc> allocator = nullptr;
+};
+
+}  // namespace rclcpp
+
+#endif  // RCLCPP__SUBSCRIPTION_OPTIONS_HPP_

--- a/rclcpp/src/rclcpp/callback_group.cpp
+++ b/rclcpp/src/rclcpp/callback_group.cpp
@@ -23,6 +23,13 @@ CallbackGroup::CallbackGroup(CallbackGroupType group_type)
 : type_(group_type), can_be_taken_from_(true)
 {}
 
+const std::vector<rclcpp::PublisherBase::WeakPtr> &
+CallbackGroup::get_publisher_ptrs() const
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  return publisher_ptrs_;
+}
+
 const std::vector<rclcpp::SubscriptionBase::WeakPtr> &
 CallbackGroup::get_subscription_ptrs() const
 {
@@ -68,6 +75,14 @@ const CallbackGroupType &
 CallbackGroup::type() const
 {
   return type_;
+}
+
+void
+CallbackGroup::add_publisher(
+  const rclcpp::PublisherBase::SharedPtr publisher_ptr)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  publisher_ptrs_.push_back(publisher_ptr);
 }
 
 void

--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -59,6 +59,8 @@ NodeParameters::NodeParameters(
       node_topics.get(),
       "parameter_events",
       parameter_event_qos_profile,
+      PublisherEventCallbacks(),
+      nullptr,
       use_intra_process,
       allocator);
   }

--- a/rclcpp/src/rclcpp/node_interfaces/node_topics.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_topics.cpp
@@ -64,11 +64,19 @@ NodeTopics::create_publisher(
 
 void
 NodeTopics::add_publisher(
-  rclcpp::PublisherBase::SharedPtr publisher)
+  rclcpp::PublisherBase::SharedPtr publisher,
+  rclcpp::callback_group::CallbackGroup::SharedPtr callback_group)
 {
-  // The publisher is not added to a callback group or anthing like that for now.
-  // It may be stored within the NodeTopics class or the NodeBase class in the future.
-  (void)publisher;
+  // Assign to a group.
+  if (callback_group) {
+    if (!node_base_->callback_group_in_node(callback_group)) {
+      throw std::runtime_error("Cannot create publisher, callback group not in node.");
+    }
+    callback_group->add_publisher(publisher);
+  } else {
+    node_base_->get_default_callback_group()->add_publisher(publisher);
+  }
+
   // Notify the executor that a new publisher was created using the parent Node.
   {
     auto notify_guard_condition_lock = node_base_->acquire_notify_guard_condition_lock();

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -214,6 +214,7 @@ void TimeSource::create_clock_sub()
     topic_name,
     std::move(cb),
     rmw_qos_profile_default,
+    rclcpp::SubscriptionEventCallbacks(),
     group,
     false,
     false,

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node_impl.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node_impl.hpp
@@ -25,6 +25,7 @@
 #include "rclcpp/create_publisher.hpp"
 #include "rclcpp/create_service.hpp"
 #include "rclcpp/create_subscription.hpp"
+#include "rclcpp/subscription_options.hpp"
 #include "rclcpp/type_support_decl.hpp"
 
 #include "lifecycle_publisher.hpp"
@@ -97,6 +98,7 @@ LifecycleNode::create_subscription(
     topic_name,
     std::forward<CallbackT>(callback),
     qos_profile,
+    rclcpp::SubscriptionEventCallbacks(),
     group,
     ignore_local_publications,
     use_intra_process_comms_,
@@ -126,6 +128,7 @@ LifecycleNode::create_subscription(
     topic_name,
     std::forward<CallbackT>(callback),
     qos,
+    rclcpp::SubscriptionEventCallbacks(),
     group,
     ignore_local_publications,
     msg_mem_strat,


### PR DESCRIPTION
Adds new PublisherOptions and SubscriptionOptions classes, with new Publisher and Subscriber constructors to accept them. 

Adds the liveliness assertion callbacks that will be needed for the new Liveliness QoS policy.

This PR introduces all of the user-code-facing interfaces that will be needed, but none of the implementations.

Signed-off-by: Emerson Knapp <eknapp@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
