### PR TITLE
fix issue with callbacks not firing in demo apps

### DIFF
--- a/rclcpp/include/rclcpp/strategies/allocator_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/allocator_memory_strategy.hpp
@@ -164,14 +164,6 @@ public:
         if (!group || !group->can_be_taken_from().load()) {
           continue;
         }
-        for (auto & weak_publisher : group->get_publisher_ptrs()) {
-          auto publisher = weak_publisher.lock();
-          if (publisher) {
-            for (auto & publisher_event : publisher->get_event_handlers()) {
-              waitable_handles_.push_back(publisher_event);
-            }
-          }
-        }
         for (auto & weak_subscription : group->get_subscription_ptrs()) {
           auto subscription = weak_subscription.lock();
           if (subscription) {
@@ -179,9 +171,6 @@ public:
             if (subscription->get_intra_process_subscription_handle()) {
               subscription_handles_.push_back(
                 subscription->get_intra_process_subscription_handle());
-            }
-            for (auto & subscription_event : subscription->get_event_handlers()) {
-              waitable_handles_.push_back(subscription_event);
             }
           }
         }

--- a/rclcpp/src/rclcpp/node_interfaces/node_topics.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_topics.cpp
@@ -72,9 +72,13 @@ NodeTopics::add_publisher(
     if (!node_base_->callback_group_in_node(callback_group)) {
       throw std::runtime_error("Cannot create publisher, callback group not in node.");
     }
-    callback_group->add_publisher(publisher);
   } else {
-    node_base_->get_default_callback_group()->add_publisher(publisher);
+    callback_group = node_base_->get_default_callback_group();
+  }
+
+  callback_group->add_publisher(publisher);
+  for (auto & publisher_event : publisher->get_event_handlers()) {
+    callback_group->add_waitable(publisher_event);
   }
 
   // Notify the executor that a new publisher was created using the parent Node.
@@ -122,9 +126,13 @@ NodeTopics::add_subscription(
       // TODO(jacquelinekay): use custom exception
       throw std::runtime_error("Cannot create subscription, callback group not in node.");
     }
-    callback_group->add_subscription(subscription);
   } else {
-    node_base_->get_default_callback_group()->add_subscription(subscription);
+    callback_group = node_base_->get_default_callback_group();
+  }
+
+  callback_group->add_subscription(subscription);
+  for (auto & subscription_event : subscription->get_event_handlers()) {
+    callback_group->add_waitable(subscription_event);
   }
 
   // Notify the executor that a new subscription was created using the parent Node.


### PR DESCRIPTION
*Description of changes:*

The event handles needed to be assigned to a callback group in order `for get_next_waitable()` to return it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.