### PR TITLE
Add method to read timer cancellation

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -397,6 +397,14 @@ if(BUILD_TESTING)
     target_link_libraries(test_time ${PROJECT_NAME})
   endif()
 
+  ament_add_gtest(test_timer test/test_timer.cpp
+          APPEND_LIBRARY_DIRS "${append_library_dirs}")
+  if(TARGET test_timer)
+    ament_target_dependencies(test_timer
+            "rcl")
+    target_link_libraries(test_timer ${PROJECT_NAME})
+  endif()
+
   ament_add_gtest(test_time_source test/test_time_source.cpp
     APPEND_LIBRARY_DIRS "${append_library_dirs}")
   if(TARGET test_time_source)

--- a/rclcpp/include/rclcpp/timer.hpp
+++ b/rclcpp/include/rclcpp/timer.hpp
@@ -58,6 +58,11 @@ public:
   void
   cancel();
 
+  /// Return the timer cancellation state.
+  RCLCPP_PUBLIC
+  bool
+  is_cancelled();
+
   RCLCPP_PUBLIC
   void
   reset();

--- a/rclcpp/src/rclcpp/timer.cpp
+++ b/rclcpp/src/rclcpp/timer.cpp
@@ -75,6 +75,17 @@ TimerBase::cancel()
   }
 }
 
+bool
+TimerBase::is_cancelled()
+{
+  bool is_canceled = false;
+  if (rcl_timer_is_canceled(timer_handle_.get(), &is_canceled) != RCL_RET_OK) {
+    throw std::runtime_error(std::string("Couldn't get timer cancelled state: ") +
+            rcl_get_error_string().str);
+  }
+  return is_canceled;
+}
+
 void
 TimerBase::reset()
 {

--- a/rclcpp/test/test_timer.cpp
+++ b/rclcpp/test/test_timer.cpp
@@ -1,0 +1,67 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <exception>
+#include <memory>
+
+#include "rcl/timer.h"
+
+#include "rclcpp/rclcpp.hpp"
+
+using namespace std::chrono_literals;
+
+class TestTimer : public ::testing::Test
+{
+protected:
+  void SetUp()
+  {
+    rclcpp::init(0, nullptr);
+    test_node = std::make_shared<rclcpp::Node>("test_timer_node");
+  }
+
+  void TearDown()
+  {
+    test_node.reset();
+    rclcpp::shutdown();
+  }
+
+  rclcpp::Node::SharedPtr test_node;
+};
+
+TEST_F(TestTimer, test_is_cancelled)
+{
+  try {
+    auto timer = test_node->create_wall_timer(1s,
+        []() -> void {
+          printf("this is a test\n");
+        }
+    );
+
+    // start and cancel
+    ASSERT_FALSE(timer->is_cancelled());
+    timer->cancel();
+    ASSERT_TRUE(timer->is_cancelled());
+
+    // reset and cancel
+    timer->reset();
+    ASSERT_FALSE(timer->is_cancelled());
+    timer->cancel();
+    ASSERT_TRUE(timer->is_cancelled());
+  } catch (std::exception & e) {
+    FAIL() << e.what();
+  }
+}


### PR DESCRIPTION
Signed-off-by: Devin Bonnie <dbbonnie@amazon.com>

Add method to read timer cancellation
Add relevant unit tests 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
